### PR TITLE
Dev-room -> devroom, de-duped whitespace

### DIFF
--- a/2020/cfp.md
+++ b/2020/cfp.md
@@ -3,64 +3,64 @@
 ## Overview
 
 [FOSDEM] is one of the world's premier meetings of free software developers,
-with over five thousand people attending each year.  FOSDEM 2020
+with over five thousand people attending each year. FOSDEM 2020
 takes place 1-2 February 2020 in Brussels, Belgium.
 
 This document contains information about:
 
-- Real-Time Communications dev-room and lounge
+- Real-Time Communications developer room (devroom) and lounge
 - speaking opportunities
-- volunteering in the dev-room and lounge
+- volunteering in the devroom and lounge
 - social events (the legendary FOSDEM Beer Night and Saturday night dinners
   provide endless networking opportunities)
 - the Planet aggregation sites for RTC blogs
 
 ## Call for participation - Real Time Communications (RTC)
 
-The Real-Time dev-room and Real-Time lounge are about all things involving
+The Real-Time devroom and Real-Time lounge are about all things involving
 real-time communication, including: XMPP, SIP, WebRTC, telephony,
 mobile VoIP, codecs, peer-to-peer, privacy and encryption.
 
-**We are looking for speakers for the dev-room and volunteers and
+**We are looking for speakers for the devroom and volunteers and
 participants for the tables in the Real-Time lounge.**
 
-The dev-room is only on Sunday, 2nd of February 2020.  The lounge will
+The devroom is only on Sunday, 2nd of February 2020. The lounge will
 be present for both days.
 
-To discuss the dev-room and lounge, please join the
+To discuss the devroom and lounge, please join the
 [Free-RTC mailing list].
 
 ### Speaking opportunities
 
 Note: if you used FOSDEM Pentabarf before, please use the same account/username
 
-Real-Time Communications dev-room: deadline 23:59 UTC on 15th of December.
+Real-Time Communications devroom: deadline 23:59 UTC on 15th of December.
 Please use the [Pentabarf] system to submit a talk proposal for the
-dev-room.  On the "General" tab, please look for the "Track" option and
+devroom. On the "General" tab, please look for the "Track" option and
 choose "Real Time Communications devroom".
 
-Other dev-rooms and lightning talks: some speakers may find their topic is
-in the scope of more than one dev-room.  It is encouraged to apply to more
-than one dev-room and also consider proposing a lightning talk, but please
+Other devrooms and lightning talks: some speakers may find their topic is
+in the scope of more than one devroom. It is encouraged to apply to more
+than one devroom and also consider proposing a lightning talk, but please
 be kind enough to tell us if you do this by filling out the notes in the form.
-Here you can find the [full list of dev-rooms] and here you can apply for
+Here you can find the [full list of devrooms] and here you can apply for
 a [lightning talk].
 
 ### First-time speaking?
 
-FOSDEM dev-rooms are a welcoming environment for people who have never
-given a talk before.  Please feel free to contact the dev-room administrators
+FOSDEM devrooms are a welcoming environment for people who have never
+given a talk before. Please feel free to contact the devroom administrators
 personally if you would like to ask any questions about it.
 
 ### Submission guidelines
 
-The Pentabarf system will ask for many of the essential details.  Please
+The Pentabarf system will ask for many of the essential details. Please
 remember to re-use your account from previous years if you have one.
 
 In the "Submission notes", please tell us about:
 
 - The purpose of your talk
-- Any other talk applications (dev-rooms, lightning talks, main track)
+- Any other talk applications (devrooms, lightning talks, main track)
 - Availability constraints and special needs
 
 You can use HTML and links in your bio, abstract and description.
@@ -68,14 +68,14 @@ You can use HTML and links in your bio, abstract and description.
 If you maintain a blog, please consider providing us with the
 URL of a feed with posts tagged for your RTC-related work.
 
-We will be looking for relevance to the conference and dev-room themes,
+We will be looking for relevance to the conference and devroom themes,
 presentations aimed at developers of free and open source software about
 RTC-related topics.
 
 Please feel free to suggest a duration between 20 minutes and 55 minutes
 but note that the final decision on talk durations will be made by the
-dev-room administrators based on the number of received proposals.
-As the two previous dev-rooms have been combined into one, we may decide to
+devroom administrators based on the number of received proposals.
+As the two previous devrooms have been combined into one, we may decide to
 give shorter slots than in previous years so that more speakers can
 participate.
 
@@ -84,7 +84,7 @@ The CC-BY license is used.
 
 ## Volunteers needed
 
-To make the dev-room and lounge run successfully, we are looking for
+To make the devroom and lounge run successfully, we are looking for
 volunteers:
 
 - FOSDEM provides video recording equipment and live streaming,
@@ -99,9 +99,9 @@ volunteers:
 The traditional FOSDEM beer night occurs on Friday, 31st of January.
 
 On Saturday night, there are usually dinners associated with
-each of the dev-rooms.  Most restaurants in Brussels are not so
+each of the devrooms. Most restaurants in Brussels are not so
 large so these dinners have space constraints and reservations are
-essential.  Please subscribe to the [Free-RTC mailing list] for
+essential. Please subscribe to the [Free-RTC mailing list] for
 further details about the Saturday night dinner options and how
 you can register for a seat.
 
@@ -114,7 +114,7 @@ are available on the [summit website].
 ## Spread the word and discuss
 
 If you know of any mailing lists where this CfP would be relevant, please
-forward this document.  If this dev-room excites you, please blog or microblog
+forward this document. If this devroom excites you, please blog or microblog
 about it, especially if you are submitting a talk.
 
 If you regularly blog about RTC topics, please send details about your
@@ -134,7 +134,7 @@ For any private queries, contact us directly using the address
 **fosdem-rtc-admin@freertc.org** and for any other queries please ask on
 the [Free-RTC mailing list].
 
-The dev-room administration team:
+The devroom administration team:
 
 - Saúl Ibarra Corretgé <s@saghul.net>
 - Ralph Meijer <ralphm@ik.nu>
@@ -145,7 +145,7 @@ The dev-room administration team:
 [FOSDEM]: https://fosdem.org
 [Free-RTC mailing list]: http://lists.freertc.org/mailman/listinfo/discuss
 [Pentabarf]: https://penta.fosdem.org/submission/FOSDEM20/
-[full list of dev-rooms]: https://www.fosdem.org/2020/schedule/tracks/
+[full list of devrooms]: https://www.fosdem.org/2020/schedule/tracks/
 [lightning talk]: https://fosdem.org/submit
 [XMPP Summit]: https://wiki.xmpp.org/web/Conferences/Summit_24
 [summit website]: https://wiki.xmpp.org/web/Conferences/Summit_24


### PR DESCRIPTION
Mintor tweaks:
- FOSDEM itself refers to "developer rooms (devrooms)", not "dev-room". I've search/replaced these for consistency.
- I replaced a couple of instances where there were two spaces, instead of one.